### PR TITLE
Disable gems/rubyopt when running generate-password.rb

### DIFF
--- a/Contents/Scripts/default.js
+++ b/Contents/Scripts/default.js
@@ -11,6 +11,8 @@ function run(format) {
 
   var password = JSON.parse(LaunchBar.execute(
     "/usr/bin/ruby",
+    "--disable=gems",
+    "--disable=rubyopt",
     "-W0",
     "generate-password.rb",
     format


### PR DESCRIPTION
Disabling these features gives us a little more speed